### PR TITLE
fix os version parsing to include full version

### DIFF
--- a/lazyScanner.py
+++ b/lazyScanner.py
@@ -40,9 +40,9 @@ class LazyScanner():
             else:
                 return
 
-            reVersion = re.search("^VERSION_ID=\"?(\w+)\"?",version,re.MULTILINE)
+            reVersion = re.search("^VERSION_ID=\"?(\w+)(.\w+)?\"?",version,re.MULTILINE)
             if reVersion:
-                osVersion = reVersion.group(1).lower()
+                osVersion = ''.join([s.lower() for s in reVersion.groups()])
             else:
                 return
             return (osFamily, osVersion)


### PR DESCRIPTION
When running on Ubuntu, the parsed version string for `14.04` is just `14`. This leads to false positives, as packages that are solely available for e.g. `14.10` are reported as vulnerabilities.

Example from an Ubuntu 14.04 server with the unfixed version of `lazyScanner.py`:
```
{:os_id=>"Ubuntu", :os_version=>"14"}
{"result"=>"OK", "data"=>{"packages"=>{"mountall 2.53 amd64"=>{"USN-2411-1"=>[{"package"=>"mountall 2.53 amd64", "providedVersion"=>"2.53", "bulletinVersion"=>"2.54ubuntu0.14.10.1", "providedPackage"=>"mountall 2.53 amd64", "bulletinPackage"=>"UNKNOWN", "operator"=>"lt", "bulletinID"=>"USN-2411-1", "cvelist"=>["CVE-2014-1421"], "fix"=>"sudo apt-get --assume-yes install --only-upgrade mountall"}]}}, "vulnerabilities"=>["USN-2411-1"], "reasons"=>[{"package"=>"mountall 2.53 amd64", "providedVersion"=>"2.53", "bulletinVersion"=>"2.54ubuntu0.14.10.1", "providedPackage"=>"mountall 2.53 amd64", "bulletinPackage"=>"UNKNOWN", "operator"=>"lt", "bulletinID"=>"USN-2411-1", "cvelist"=>["CVE-2014-1421"], "fix"=>"sudo apt-get --assume-yes install --only-upgrade mountall"}], "cvss"=>{"score"=>7.2, "vector"=>"AV:LOCAL/AC:LOW/Au:NONE/C:COMPLETE/I:COMPLETE/A:COMPLETE/"}, "cvelist"=>["CVE-2014-1421"], "cumulativeFix"=>"sudo apt-get --assume-yes install --only-upgrade mountall", "id"=>"..."}}
```

This fix causes the parsed version string to be `14.04` in this example. It should not break the rest of the OSes.